### PR TITLE
chore: Add witness policy cache expiry parameter

### DIFF
--- a/docs/source/orb/parameters.md
+++ b/docs/source/orb/parameters.md
@@ -336,3 +336,7 @@ The expiration time of an ActivityPub actor IRI cache.
 ## SERVER_IDLE_TIMEOUT
 
 The idle timeout for the HTTP server. For example, '30s' for a 30 second timeout.
+
+## WITNESS_POLICY_CACHE_EXPIRATION
+
+The expiration time(period) of witness policy cache. Default value is 30s.

--- a/docs/source/orb/sidetree.md
+++ b/docs/source/orb/sidetree.md
@@ -24,7 +24,7 @@ operations together and store them in Sidetree batch files as per
 
 Next, Sidetree batch file information will be stored into anchor index and anchor index will be witnessed 
 as per witness policy. Observer will process witnessed anchor index and Sidetree batches as per 
-[Sidetree transaction operation processing] (https://identity.foundation/sidetree/spec/#transaction-operation-processing) 
+[Sidetree transaction operation processing](https://identity.foundation/sidetree/spec/#transaction-operation-processing) 
 and store DID operations into operations store.  It will delete observed DID operation from unpublished operation store.
 DID will be resolved from stored DID operations.
 


### PR DESCRIPTION
Add witenss policy cache expiry parameter. Fix link in Sidetree documentation.

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>