### PR TITLE
docs: Use arg names instead of environment variables as headings

### DIFF
--- a/docs/source/orb/activitypub.md
+++ b/docs/source/orb/activitypub.md
@@ -176,7 +176,7 @@ activity is posted to the originating server.
 ### Follow Authorization Policy
 
 An authorization policy may be configured for the [Follow](#follow) activity using the configuration parameters,
-[FOLLOW_AUTH_POLICY](parameters.html#follow-auth-policy). The possible values are  _accept-all_ and _accept-list_. If
+[follow-auth-policy](parameters.html#follow-auth-policy). The possible values are  _accept-all_ and _accept-list_. If
 accept-all
 is used then all Follow requests are accepted. If accept-list is used then the actor in the Follow activity must be in the
 [accept-list](#accept-list) database.
@@ -184,7 +184,7 @@ is used then all Follow requests are accepted. If accept-list is used then the a
 ### Invite Witness Authorization Policy
 
 An authorization policy may be configured for the [Invite Witness](#invite-witness) activity using the configuration
-parameters, [INVITE_WITNESS_AUTH_POLICY](parameters.html#invite-witness-auth-policy). The possible values are  _accept-all_
+parameters, [invite-witness-auth-policy](parameters.html#invite-witness-auth-policy). The possible values are  _accept-all_
 and _accept-list_. If accept-all is used then all Invite witness requests are accepted. If accept-list is used then the
 actor in the Invite activity must be in the [accept-list](#accept-list) database.
 

--- a/docs/source/orb/authorization.md
+++ b/docs/source/orb/authorization.md
@@ -15,7 +15,7 @@ Authorization:[Bearer mytoken]
 
 The server matches the bearer token in the request header against the required token(s) for the particular endpoint.
 Each REST endpoint may be
-[configured](parameters.html#orb-auth-tokens-def) to require tokens for both read (GET) and write (POST)
+[configured](parameters.html#auth-tokens-def) to require tokens for both read (GET) and write (POST)
 requests. If no token is defined for an endpoint then no authorization is performed. Multiple tokens may be defined
 for read and write requests. If more than one token is defined then authorization succeeds if any of the tokens is found
 in the request header. If a token for the request is required but not found in the request header then
@@ -27,7 +27,7 @@ in the request header. If a token for the request is required but not found in t
 ## HTTP Signatures
 
 A common HTTP client within Orb is used for all server-to-server communications. If HTTP signatures are
-[enabled](parameters.html#http-signatures-enabled) then the HTTP client sets additional headers on the HTTP
+[enabled](parameters.html#enable-http-signatures) then the HTTP client sets additional headers on the HTTP
 request.
 
 ### Headers
@@ -130,5 +130,5 @@ appropriate handler. (The actor may be used by the handler to perform authorizat
 
 ```
 
-Note that public keys and actors are cached (with an [expiry](parameters.html#activitypub-client-cache-expiration))
+Note that public keys and actors are cached (with an [expiry](parameters.html#apclient-cache-expiration))
 so that remote calls aren't required each time a signature verification is performed.

--- a/docs/source/orb/metrics.md
+++ b/docs/source/orb/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-An Orb server records performance metrics at each subsystem. A [Prometheus](https://prometheus.io/) server may be used to periodically read the metrics at the URL specified by the startup parameter, [ORB_HOST_METRICS_URL](parameters.html#startup-parameters). Below are the metrics defined at each subsystem.
+An Orb server records performance metrics at each subsystem. A [Prometheus](https://prometheus.io/) server may be used to periodically read the metrics at the URL specified by the startup parameter, [host-metrics-url](parameters.html#host-metrics-url). Below are the metrics defined at each subsystem.
 
 ## ActivityPub
 

--- a/docs/source/orb/onboardrecover.md
+++ b/docs/source/orb/onboardrecover.md
@@ -13,7 +13,7 @@ following.
 ## Activity Sync Task
 
 When an Orb server starts up, an _activity sync_ task is registered with the
-[Task Manager](taskmanager.html#task-manager). This task [periodically](parameters.html#anchor-event-sync-interval)
+[Task Manager](taskmanager.html#task-manager). This task [periodically](parameters.html#sync-interval)
 synchronizes anchor activities ([Create](https://trustbloc.github.io/activityanchors/#create-activity)
 and [Announce](https://trustbloc.github.io/activityanchors/#announce-activity)) with the
 domains that the local domain is following and also processes any missing anchor
@@ -30,7 +30,7 @@ Announce activities.
 
 When processing an activity, the timestamp of when the activity was published is used to determine
 the _age_ of the activity. The activity is not processed unless its age has reached the configured
-[minimum activity age](parameters.html#anchor-event-sync-min-activity-age). This is done to minimize
+[minimum activity age](parameters.html#sync-min-activity-age). This is done to minimize
 the possibility of both the [Inbox](activitypub.html#outbox-inbox) and the activity sync task concurrently
 processing the anchor event. (Even though the system is tolerant of this situation, it still has an impact
 on performance.)

--- a/docs/source/orb/parameters.md
+++ b/docs/source/orb/parameters.md
@@ -9,7 +9,7 @@ default value if not specified.
 
 Following are the required parameters for an Orb server.
 
-### ORB_HOST_URL
+### host-url
 
 | Arg        | Env           |
 |------------|---------------|
@@ -17,7 +17,7 @@ Following are the required parameters for an Orb server.
 
 URL to run the orb-server instance on. Format: HostName:Port.
 
-### ORB_EXTERNAL_ENDPOINT
+### external-endpoint
 
 | Arg                 | Env                    |
 |---------------------|------------------------|
@@ -25,7 +25,7 @@ URL to run the orb-server instance on. Format: HostName:Port.
 
 External endpoint that clients use to invoke services. This endpoint is used to generate IDs of anchor credentials and ActivityPub objects and should be resolvable by external clients. Format: HostName[:Port].
 
-### DATABASE_TYPE
+### database-type
 
 | Arg             | Env            |
 |-----------------|----------------|
@@ -33,7 +33,7 @@ External endpoint that clients use to invoke services. This endpoint is used to 
 
 The type of database to use for everything except key storage. Supported options: mem, couchdb, mongodb.
 
-### ORB_PRIVATE_KEYS
+### private-keys
 
 | Arg            | Env              |
 |----------------|------------------|
@@ -41,7 +41,7 @@ The type of database to use for everything except key storage. Supported options
 
 Private Keys base64 (ED25519Type). For example,  key1=privatekeyBase64Value,key2=privatekeyBase64Value
 
-### ORB_ACTIVE_KEY_ID
+### active-key-id
 
 | Arg             | Env              - |
 |-----------------|--------------------|
@@ -49,7 +49,7 @@ Private Keys base64 (ED25519Type). For example,  key1=privatekeyBase64Value,key2
 
 Active Key ID (ED25519Type).
 
-### DID_NAMESPACE
+### did-namespace
 
 | Arg             | Env            |
 |-----------------|----------------|
@@ -57,7 +57,7 @@ Active Key ID (ED25519Type).
 
 DID Namespace.
 
-### CAS_TYPE
+### cas-type
 
 | Arg        | Env       |
 |------------|-----------|
@@ -65,7 +65,7 @@ DID Namespace.
 
 The type of the Content Addressable Storage (CAS). Supported options: local, ipfs.
 
-### ANCHOR_CREDENTIAL_ISSUER
+### anchor-credential-issuer
 
 | Arg                        | Env                      |
 |----------------------------|--------------------------|
@@ -73,7 +73,7 @@ The type of the Content Addressable Storage (CAS). Supported options: local, ipf
 
 Anchor credential issuer (required).
 
-### ANCHOR_CREDENTIAL_URL
+### anchor-credential-url
 
 | Arg                     | Env                    |
 |-------------------------|------------------------|
@@ -81,7 +81,7 @@ Anchor credential issuer (required).
 
 Anchor credential url (required).
 
-### ANCHOR_CREDENTIAL_SIGNATURE_SUITE
+### anchor-credential-signature-suite
 
 | Arg                                 | Env                                 |
 |-------------------------------------|-------------------------------------|
@@ -93,7 +93,7 @@ Anchor credential signature suite (required).
 
 Below are the optional parameters for an Orb server. If not specified then the default value is used.
 
-### ORB_HOST_METRICS_URL
+### host-metrics-url
 
 | Arg                | Env                  | Default |
 |--------------------|----------------------|---------|
@@ -101,7 +101,7 @@ Below are the optional parameters for an Orb server. If not specified then the d
 
 URL that exposes the metrics endpoint. Format: HostName:Port.
 
-### ORB_SYNC_TIMEOUT
+### sync-timeout
 
 | Arg            | Env              | Default |
 |----------------|------------------|---------|
@@ -109,7 +109,7 @@ URL that exposes the metrics endpoint. Format: HostName:Port.
 
 Total time in seconds to resolve config values.
 
-### ORB_VCT_URL
+### vct-url
 
 | Arg       | Env          | Default  |
 |-----------|--------------|----------|
@@ -117,7 +117,7 @@ Total time in seconds to resolve config values.
 
 Verifiable credential transparency URL.
 
-### VCT_MONITORING_INTERVAL
+### vct-monitoring-interval
 
 | Arg                       | Env                     | Default |
 |---------------------------|-------------------------|---------|
@@ -125,7 +125,7 @@ Verifiable credential transparency URL.
 
 The interval in which VCTs are monitored to ensure that proofs are anchored.
 
-### ANCHOR_STATUS_MONITORING_INTERVAL
+### anchor-status-monitoring-interval
 
 | Arg                                 | Env                               | Default |
 |-------------------------------------|-----------------------------------|---------|
@@ -134,7 +134,7 @@ The interval in which VCTs are monitored to ensure that proofs are anchored.
 The interval in which 'in-process' anchors are monitored to ensure that they will be witnessed(completed) as per
 policy.
 
-### ANCHOR_STATUS_IN_PROCESS_GRACE_PERIOD
+### anchor-status-in-process-grace-period
 
 | Arg                                     | Env                                   | Default |
 |-----------------------------------------|---------------------------------------|---------|
@@ -142,7 +142,7 @@ policy.
 
 The period in which witnesses will not be re-selected for 'in-process' anchors.
 
-### ORB_KMS_STORE_ENDPOINT
+### kms-store-endpoint
 
 | Arg                  | Env                     | Default |
 |----------------------|-------------------------|---------|
@@ -150,7 +150,7 @@ The period in which witnesses will not be re-selected for 'in-process' anchors.
 
 KMS storage URL. If this parameter is not set then ORB_KMS_ENDPOINT needs to be set.
 
-### ORB_KMS_ENDPOINT
+### kms-endpoint
 
 | Arg            | Env               | Default |
 |----------------|-------------------|---------|
@@ -158,7 +158,7 @@ KMS storage URL. If this parameter is not set then ORB_KMS_ENDPOINT needs to be 
 
 Remote KMS URL. If this parameter is not set then ORB_KMS_STORE_ENDPOINT needs to be set.
 
-### ORB_SECRET_LOCK_KEY_PATH
+### secret-lock-key-path
 
 | Arg                    | Env                       | Default |
 |------------------------|---------------------------|---------|
@@ -166,7 +166,7 @@ Remote KMS URL. If this parameter is not set then ORB_KMS_STORE_ENDPOINT needs t
 
 The path to the file with key to be used by local secret lock. If missing noop service lock is used.
 
-### ORB_DISCOVERY_DOMAIN
+### discovery-domain
 
 | Arg                | Env                   | Default |
 |--------------------|-----------------------|---------|
@@ -174,7 +174,7 @@ The path to the file with key to be used by local secret lock. If missing noop s
 
 Discovery domain for this domain. Format: HostName
 
-### ORB_TLS_SYSTEMCERTPOOL
+### tls-systemcertpool
 
 | Arg                  | Env                     | Default |
 |----------------------|-------------------------|---------|
@@ -182,7 +182,7 @@ Discovery domain for this domain. Format: HostName
 
 Use system certificate pool. Possible values true and false. Defaults to false if not set.
 
-### ORB_TLS_CACERTS
+### tls-cacerts
 
 | Arg           | Env              | Default |
 |---------------|------------------|---------|
@@ -190,7 +190,7 @@ Use system certificate pool. Possible values true and false. Defaults to false i
 
 Comma-Separated list of ca certs path.
 
-### ORB_TLS_CERTIFICATE
+### tls-certificate
 
 | Arg               | Env                  | Default |
 |-------------------|----------------------|---------|
@@ -198,7 +198,7 @@ Comma-Separated list of ca certs path.
 
 TLS certificate for ORB server.
 
-### ORB_TLS_KEY
+### tls-key
 
 | Arg       | Env          | Default |
 |-----------|--------------|---------|
@@ -206,7 +206,7 @@ TLS certificate for ORB server.
 
 TLS key for ORB server.
 
-### DID_ALIASES
+### did-aliases
 
 | Arg           | Env          | Default |
 |---------------|--------------|---------|
@@ -214,7 +214,7 @@ TLS key for ORB server.
 
 Aliases for this did method.
 
-### IPFS_URL
+### ipfs-url
 
 | Arg        | Env       | Default |
 |------------|-----------|---------|
@@ -222,7 +222,7 @@ Aliases for this did method.
 
 Enables IPFS support. If set, this Orb server will use the node at the given URL. To use the public ipfs.io node, set this to https://ipfs.io (or http://ipfs.io). If using ipfs.io, then the CAS type flag must be set to local since the ipfs.io node is read-only. If the URL doesn't include a scheme, then HTTP will be used by default.
 
-### REPLICATE_LOCAL_CAS_WRITES_IN_IPFS
+### replicate-local-cas-writes-in-ipfs
 
 | Arg                                   | Env                                | Default |
 |---------------------------------------|------------------------------------|---------|
@@ -230,7 +230,7 @@ Enables IPFS support. If set, this Orb server will use the node at the given URL
 
 If enabled, writes to the local CAS will also be replicated in IPFS. This setting only takes effect if this server has both a local CAS and IPFS enabled. If the IPFS node is set to ipfs.io, then this setting will be disabled since ipfs.io does not support writes. Supported options: false, true. Defaults to false if not set.
 
-### MQ_URL
+### mq-url
 
 | Arg      | Env     | Default |
 |----------|---------|---------|
@@ -238,7 +238,7 @@ If enabled, writes to the local CAS will also be replicated in IPFS. This settin
 
 The URL of the message broker. If not specified then an in-memory message queue is used.
 
-### MQ_CONNECT_MAX_RETRIES
+### mq-connect-max-retries
 
 | Arg                      | Env                    | Default |
 |--------------------------|------------------------|---------|
@@ -246,7 +246,7 @@ The URL of the message broker. If not specified then an in-memory message queue 
 
 The maximum number of retries to connect to an AMQP service, after which the server will panic.
 
-### MQ_OBSERVER_POOL
+### mq-observer-pool
 
 | Arg                | Env              | Default |
 |--------------------|------------------|---------|
@@ -254,15 +254,15 @@ The maximum number of retries to connect to an AMQP service, after which the ser
 
 The size of the observer queue subscriber pool. If not specified then the default size will be used.
 
-### MQ_MAX_CONNECTION_SUBSCRIPTIONS
+### mq-max-connection-subscriptions
 
 | Arg                               | Env                             | Default  |
 |-----------------------------------|---------------------------------|----------|
-| --mq-max-connection-subscription  | MQ_MAX_CONNECTION_SUBSCRIPTIONS | 1000     |
+| --mq-max-connection-subscriptions | MQ_MAX_CONNECTION_SUBSCRIPTIONS | 1000     |
 
 The maximum number of subscriptions per connection.
 
-### MQ_PUBLISHER_POOL
+### mq-publisher-channel-pool-size
 
 | Arg                              | Env               | Default |
 |----------------------------------|-------------------|---------|
@@ -270,7 +270,7 @@ The maximum number of subscriptions per connection.
 
 The size of a channel pool for an AMQP publisher (default is 25). If set to 0 then a channel pool is not used and a new channel is opened/closed for every publish to a queue.
 
-### MQ_REDELIVERY_MAX_ATTEMPTS
+### mq-redelivery-max-attempts
 
 | Arg                               | Env                    | Default |
 |-----------------------------------|------------------------|---------|
@@ -278,7 +278,7 @@ The size of a channel pool for an AMQP publisher (default is 25). If set to 0 th
 
 The maximum number of redelivery attempts for a failed message.
 
-### MQ_REDELIVERY_INITIAL_INTERVAL
+### mq-redelivery-initial-interval
 
 | Arg                                | Env                            | Default |
 |------------------------------------|--------------------------------|---------|
@@ -286,7 +286,7 @@ The maximum number of redelivery attempts for a failed message.
 
 The delay for the initial redelivery attempt.
 
-### MQ_REDELIVERY_MULTIPLIER
+### mq-redelivery-multiplier
 
 | Arg                        | Env                      | Default |
 |----------------------------|--------------------------|---------|
@@ -295,7 +295,7 @@ The delay for the initial redelivery attempt.
 The multiplier for a redelivery attempt. For example, if set to 1.5 and the previous
 redelivery interval was 2s then the next redelivery interval is set 3s.
 
-### MQ_REDELIVERY_MAX_INTERVAL
+### mq-redelivery-max-interval
 
 | Arg                          | Env                        | Default |
 |------------------------------|----------------------------|---------|
@@ -303,7 +303,7 @@ redelivery interval was 2s then the next redelivery interval is set 3s.
 
 The maximum delay for a redelivery.
 
-### OP_QUEUE_POOL
+### op-queue-pool
 
 | Arg             | Env           | Default  |
 |-----------------|---------------|----------|
@@ -311,7 +311,7 @@ The maximum delay for a redelivery.
 
 The size of the operation queue subscriber pool. If <=1 then a pool will not be created.
 
-### OP_QUEUE_TASK_MONITOR_INTERVAL
+### op-queue-task-monitor-interval
 
 | Arg                              | Env                            | Default |
 |----------------------------------|--------------------------------|---------|
@@ -319,7 +319,7 @@ The size of the operation queue subscriber pool. If <=1 then a pool will not be 
 
 The interval (period) in which operation queue tasks from other server instances are monitored.
 
-### OP_QUEUE_TASK_EXPIRATION
+### op-queue-task-expiration
 
 | Arg                        | Env                      | Default |
 |----------------------------|--------------------------|---------|
@@ -329,7 +329,7 @@ The maximum time that an operation queue task can exist in the database before i
 Once expired, any other server instance may delete the task and repost operations associated with the task
 to the queue, so that they will be processed by another Orb instance.
 
-### OP_QUEUE_MAX_REPOSTS
+### op-queue-max-reposts
 
 | Arg                    | Env                  | Default |
 |------------------------|----------------------|---------|
@@ -337,7 +337,7 @@ to the queue, so that they will be processed by another Orb instance.
 
 The maximum number of times an operation may be reposted to the queue after having failed.
 
-### CID_VERSION
+### cid-version
 
 | Arg           | Env          | Default |
 |---------------|--------------|---------|
@@ -345,7 +345,7 @@ The maximum number of times an operation may be reposted to the queue after havi
 
 The version of the CID format to use for generating CIDs. Supported options: 0, 1. If not set, defaults to 1.
 
-### BATCH_WRITER_TIMEOUT
+### batch-writer-timeout
 
 | Arg                    | Env                   | Default |
 |------------------------|-----------------------|---------|
@@ -353,7 +353,7 @@ The version of the CID format to use for generating CIDs. Supported options: 0, 
 
 Maximum time (in millisecond) in-between cutting batches.
 
-### DATABASE_URL
+### database-url
 
 | Arg            | Env           | Default  |
 |----------------|---------------|----------|
@@ -361,7 +361,7 @@ Maximum time (in millisecond) in-between cutting batches.
 
 The URL (or connection string) of the database. Not needed if using memstore. For CouchDB, include the username:password@ text if required.
 
-### DATABASE_PREFIX
+### database-prefix
 
 | Arg               | Env              | Default |
 |-------------------|------------------|---------|
@@ -370,7 +370,7 @@ The URL (or connection string) of the database. Not needed if using memstore. Fo
 An optional prefix to be used when creating and retrieving underlying databases. This allows
 a database to be shared by multiple Orb domains. (Mainly used in development environments.)
 
-### KMSSECRETS_DATABASE_TYPE
+### kms-secrets-database-type
 
 | Arg                         | Env                       | Default  |
 |-----------------------------|---------------------------|----------|
@@ -378,7 +378,7 @@ a database to be shared by multiple Orb domains. (Mainly used in development env
 
 The type of database to use for storage of KMS secrets. Supported options: mem, couchdb, mongodb.
 
-### KMSSECRETS_DATABASE_URL
+### kms-secrets-database-url
 
 | Arg                        | Env                      | Default |
 |----------------------------|--------------------------|---------|
@@ -386,7 +386,7 @@ The type of database to use for storage of KMS secrets. Supported options: mem, 
 
 The URL (or connection string) of the database. Not needed if using memstore. For CouchDB, include the username:password@ text if required.
 
-### KMSSECRETS_DATABASE_PREFIX
+### kms-secrets-database-prefix
 
 | Arg                           | Env                         | Default |
 |-------------------------------|-----------------------------|---------|
@@ -395,14 +395,15 @@ The URL (or connection string) of the database. Not needed if using memstore. Fo
 An optional prefix to be used when creating and retrieving the underlying KMS secrets database.
 This allows a database to be shared by multiple Orb domains. (Mainly used in development environments.)
 
-### DATABASE_TIMEOUT
+### database-timeout
 
 | Arg                | Env               | Default |
 |--------------------|-------------------|---------|
 | --database-timeout | DATABASE_TIMEOUT  | 10s     |
 
 The timeout for database requests. For example, '30s' for a 30 second timeout. Currently this setting only applies if you're using MongoDB.
-### ANCHOR_CREDENTIAL_DOMAIN
+
+### anchor-credential-domain
 
 | Arg                        | Env                       | Default               |
 |----------------------------|---------------------------|-----------------------|
@@ -410,7 +411,7 @@ The timeout for database requests. For example, '30s' for a 30 second timeout. C
 
 Anchor credential domain.
 
-### ALLOWED_ORIGINS
+### allowed-origins
 
 | Arg               | Env              | Default |
 |-------------------|------------------|---------|
@@ -418,7 +419,7 @@ Anchor credential domain.
 
 Allowed origins for this did method.
 
-### MAX_WITNESS_DELAY
+### max-witness-delay
 
 | Arg                 | Env                | Default |
 |---------------------|--------------------|---------|
@@ -426,7 +427,7 @@ Allowed origins for this did method.
 
 Maximum witness response time.
 
-### SIGN_WITH_LOCAL_WITNESS
+### sign-with-local-witness
 
 | Arg                       | Env                      | Default |
 |---------------------------|--------------------------|---------|
@@ -434,7 +435,7 @@ Maximum witness response time.
 
 Always sign with local witness flag (default true).
 
-### DISCOVERY_DOMAINS
+### discovery-domains
 
 | Arg                 | Env                | Default |
 |---------------------|--------------------|---------|
@@ -442,7 +443,7 @@ Always sign with local witness flag (default true).
 
 Discovery domains.
 
-### DISCOVERY_VCT_DOMAINS
+### discovery-vct-domains
 
 | Arg                     | Env                    | Default |
 |-------------------------|------------------------|---------|
@@ -450,7 +451,7 @@ Discovery domains.
 
 Discovery VCT domains.
 
-### DISCOVERY_MINIMUM_RESOLVERS
+### discovery-minimum-resolvers
 
 | Arg                           | Env                          | Default |
 |-------------------------------|------------------------------|---------|
@@ -458,7 +459,7 @@ Discovery VCT domains.
 
 Discovery minimum resolvers number.
 
-### HTTP_SIGNATURES_ENABLED
+### enable-http-signatures
 
 | Arg                      | Env                      | Default |
 |--------------------------|--------------------------|---------|
@@ -466,7 +467,7 @@ Discovery minimum resolvers number.
 
 Set to "true" to enable HTTP signatures in ActivityPub.
 
-### DID_DISCOVERY_ENABLED
+### enable-did-discovery
 
 | Arg                    | Env                    | Default |
 |------------------------|------------------------|---------|
@@ -474,7 +475,7 @@ Set to "true" to enable HTTP signatures in ActivityPub.
 
 Set to "true" to enable did discovery.
 
-### UNPUBLISHED_OPERATION_STORE_ENABLED
+### enable-unpublished-operation-store
 
 | Arg                                  | Env                                 | Default |
 |--------------------------------------|-------------------------------------|---------|
@@ -482,7 +483,7 @@ Set to "true" to enable did discovery.
 
 Set to "true" to enable un-published operation store. Used to enable storing unpublished operations and including them when resolving documents.
 
-### UNPUBLISHED_OPERATION_STORE_OPERATION_TYPES
+### unpublished-operation-store-operation-types
 
 | Arg                                           | Env                                          | Default        |
 |-----------------------------------------------|----------------------------------------------|----------------|
@@ -492,7 +493,7 @@ Comma-separated list of operation types. Used if unpublished operation store is 
 Default value is "create,update" which enables storing unpublished 'create' and 'update' operations into
 unpublished store and using those unpublished 'create' and 'update' operations for resolving document.
 
-### INCLUDE_UNPUBLISHED_OPERATIONS_IN_METADATA
+### include-unpublished-operations-in-metadata
 
 | Arg                                          | Env                                         | Default |
 |----------------------------------------------|---------------------------------------------|---------|
@@ -500,7 +501,7 @@ unpublished store and using those unpublished 'create' and 'update' operations f
 
 Set to "true" to include unpublished operations in metadata.
 
-### INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA
+### include-published-operations-in-metadata
 
 | Arg                                        | Env                                       | Default |
 |--------------------------------------------|-------------------------------------------|---------|
@@ -508,7 +509,7 @@ Set to "true" to include unpublished operations in metadata.
 
 Set to "true" to include published operations in metadata.
 
-### RESOLVE_FROM_ANCHOR_ORIGIN
+### resolve-from-anchor-origin
 
 | Arg                          | Env                         | Default |
 |------------------------------|-----------------------------|---------|
@@ -516,7 +517,7 @@ Set to "true" to include published operations in metadata.
 
 Set to "true" to resolve from anchor origin.
 
-### VERIFY_LATEST_FROM_ANCHOR_ORIGIN
+### verify-latest-from-anchor-origin
 
 | Arg                                | Env                               | Default |
 |------------------------------------|-----------------------------------|---------|
@@ -524,7 +525,7 @@ Set to "true" to resolve from anchor origin.
 
 Set to "true" to verify latest operations against anchor origin.
 
-### ORB_AUTH_TOKENS_DEF
+### auth-tokens-def
 
 | Arg                 | Env                                | Default |
 |---------------------|------------------------------------|---------|
@@ -554,7 +555,7 @@ ORB_AUTH_TOKENS_DEF=/services/orb/outbox|admin&read|admin,/services/orb/.*|read&
 - The client requires an 'admin' token in order to post to the outbox
 - The client requires a 'read' or 'admin' token in order to perform a GET on any endpoint starting with /services/orb/
 
-### ORB_AUTH_TOKENS
+### auth-tokens
 
 | Arg           | Env              | Default |
 |---------------|------------------|---------|
@@ -566,7 +567,7 @@ Specifies the actual values of the tokens defined in ORB_AUTH_TOKENS_DEF.
 
 admin=ADMIN_PASSWORD,read=READ_PASSWORD
 
-### ORB_CLIENT_AUTH_TOKENS_DEF
+### client-auth-tokens-def
 
 | Arg                      | Env                         | Default             |
 |--------------------------|-----------------------------|---------------------|
@@ -576,7 +577,7 @@ Follows the same rules as ORB_AUTH_TOKENS_DEF but is used by the Orb client tran
 determine whether an HTTP signature is required for an outbound HTTP request. If not specified then it is assumed
 to be the same as ORB_AUTH_TOKENS_DEF.
 
-### ORB_CLIENT_AUTH_TOKENS
+### client-auth-tokens
 
 | Arg                  | Env                     | Default         |
 |----------------------|-------------------------|-----------------|
@@ -584,7 +585,7 @@ to be the same as ORB_AUTH_TOKENS_DEF.
 
 Specifies the actual values of the tokens defined in ORB_CLIENT_AUTH_TOKENS_DEF. If not specified then it is assumed to be the same as ORB_AUTH_TOKENS.
 
-### ACTIVITYPUB_PAGE_SIZE
+### activitypub-page-size
 
 | Arg                     | Env                    | Default |
 |-------------------------|------------------------|---------|
@@ -592,7 +593,7 @@ Specifies the actual values of the tokens defined in ORB_CLIENT_AUTH_TOKENS_DEF.
 
 The maximum page size for an ActivityPub collection or ordered collection.
 
-### DEV_MODE_ENABLED
+### enable-dev-mode
 
 | Arg               | Env               | Default |
 |-------------------|-------------------|---------|
@@ -600,7 +601,7 @@ The maximum page size for an ActivityPub collection or ordered collection.
 
 Set to "true" to enable dev mode. When dev mode is enabled, no TLS is used.
 
-### NODEINFO_REFRESH_INTERVAL
+### nodeinfo-refresh-interval
 
 | Arg                         | Env                        | Default |
 |-----------------------------|----------------------------|---------|
@@ -608,7 +609,7 @@ Set to "true" to enable dev mode. When dev mode is enabled, no TLS is used.
 
 The interval for refreshing NodeInfo data. For example, '30s' for a 30 second interval.
 
-### IPFS_TIMEOUT
+### ipfs-timeout
 
 | Arg            | Env           | Default |
 |----------------|---------------|---------|
@@ -616,7 +617,7 @@ The interval for refreshing NodeInfo data. For example, '30s' for a 30 second in
 
 The timeout for IPFS requests. For example, '30s' for a 30 second timeout.
 
-### ORB_CONTEXT_PROVIDER_URL
+### context-provider-url
 
 | Arg                    | Env                       | Default |
 |------------------------|---------------------------|---------|
@@ -624,7 +625,7 @@ The timeout for IPFS requests. For example, '30s' for a 30 second timeout.
 
 Comma-separated list of remote context provider URLs to get JSON-LD contexts from."
 
-### UNPUBLISHED_OPERATION_LIFETIME
+### unpublished-operation-lifetime
 
 | Arg                              | Env                             | Default |
 |----------------------------------|---------------------------------|---------|
@@ -632,7 +633,7 @@ Comma-separated list of remote context provider URLs to get JSON-LD contexts fro
 
 How long unpublished operations remain stored before expiring (and thus, being deleted some time later). For example, '1m' for a 1 minute lifespan. Defaults to 1 minute if not set.
 
-### TASK_MANAGER_CHECK_INTERVAL
+### task-manager-check-interval
 
 | Arg                           | Env                          | Default |
 |-------------------------------|------------------------------|---------|
@@ -640,7 +641,7 @@ How long unpublished operations remain stored before expiring (and thus, being d
 
 How frequently to check for scheduled tasks. For example, a setting of '10s' will cause the task manager to check for outstanding tasks every 10s. Defaults to 10 seconds if not set.
 
-### DATA_EXPIRY_CHECK_INTERVAL
+### data-expiry-check-interval
 
 | Arg                          | Env                         | Default |
 |------------------------------|-----------------------------|---------|
@@ -648,7 +649,7 @@ How frequently to check for scheduled tasks. For example, a setting of '10s' wil
 
 How frequently to check for (and delete) any expired data. For example, a setting of '1m' will cause the expiry service to run a check every 1 minute. Defaults to 1 minute if not set.
 
-### FOLLOW_AUTH_POLICY
+### follow-auth-policy
 
 | Arg                  | Env                 | Default    |
 |----------------------|---------------------|------------|
@@ -656,7 +657,7 @@ How frequently to check for (and delete) any expired data. For example, a settin
 
 The type of authorization to use when a 'Follow' ActivityPub request is received. Possible values are: 'accept-all' and 'accept-list'. The value, 'accept-all', indicates that this server will accept any 'Follow' request. The value, 'accept-list', indicates that the service sending the 'Follow' request must be included in an 'accept list'. Defaults to 'accept-all' if not set.
 
-### INVITE_WITNESS_AUTH_POLICY
+### invite-witness-auth-policy
 
 | Arg                          | Env                         | Default    |
 |------------------------------|-----------------------------|------------|
@@ -664,7 +665,7 @@ The type of authorization to use when a 'Follow' ActivityPub request is received
 
 The type of authorization to use when a 'Invite' witness ActivityPub request is received. Possible values are: 'accept-all' and 'accept-list'. The value, 'accept-all', indicates that this server will accept any 'Invite' request for a witness. The value, 'accept-list', indicates that the service sending the 'Invite' witness request must be included in an 'accept list'. Defaults to 'accept-all' if not set.
 
-### HTTP_TIMEOUT
+### http-timeout
 
 | Arg            | Env           | Default |
 |----------------|---------------|----------|
@@ -672,7 +673,7 @@ The type of authorization to use when a 'Invite' witness ActivityPub request is 
 
 The timeout for http requests. For example, '30s' for a 30 second timeout.
 
-### HTTP_DIAL_TIMEOUT
+### http-dial-timeout
 
 | Arg                 | Env                | Default |
 |---------------------|--------------------|---------|
@@ -680,7 +681,7 @@ The timeout for http requests. For example, '30s' for a 30 second timeout.
 
 The timeout for HTTP dial. For example, '30s' for a 30 second timeout.
 
-### ANCHOR_EVENT_SYNC_INTERVAL
+### sync-interval
 
 | Arg             | Env                         | Default |
 |-----------------|-----------------------------|---------|
@@ -688,7 +689,7 @@ The timeout for HTTP dial. For example, '30s' for a 30 second timeout.
 
 The interval in which anchor events are synchronized with other services that this service is following. Defaults to 1m if not set.
 
-### ANCHOR_EVENT_SYNC_MIN_ACTIVITY_AGE
+### sync-min-activity-age
 
 | Arg                     | Env                                 | Default |
 |-------------------------|-------------------------------------|---------|
@@ -697,7 +698,7 @@ The interval in which anchor events are synchronized with other services that th
 The minimum age of an anchor activity to be synchronized. The activity will be processed only if its age is
 greater than this value. Defaults to 1m if not set.
 
-### ACTIVITYPUB_CLIENT_CACHE_SIZE
+### apclient-cache-size
 
 | Arg                   | Env                            | Default |
 |-----------------------|--------------------------------|---------|
@@ -705,7 +706,7 @@ greater than this value. Defaults to 1m if not set.
 
 The maximum size of an ActivityPub service and public key cache.
 
-### ACTIVITYPUB_CLIENT_CACHE_EXPIRATION
+### apclient-cache-Expiration
 
 | Arg                         | Env                                  | Default |
 |-----------------------------|--------------------------------------|---------|
@@ -713,7 +714,7 @@ The maximum size of an ActivityPub service and public key cache.
 
 The expiration time of an ActivityPub service and public key cache.
 
-### ACTIVITYPUB_IRI_CACHE_SIZE
+### apiri-cache-size
 
 | Arg                | Env                         | Default |
 |--------------------|-----------------------------|---------|
@@ -721,7 +722,7 @@ The expiration time of an ActivityPub service and public key cache.
 
 The maximum size of an ActivityPub actor IRI cache.
 
-### ACTIVITYPUB_IRI_CACHE_EXPIRATION
+### apiri-cache-Expiration
 
 | Arg                      | Env                               | Default |
 |--------------------------|-----------------------------------|---------|
@@ -729,7 +730,7 @@ The maximum size of an ActivityPub actor IRI cache.
 
 The expiration time of an ActivityPub actor IRI cache.
 
-### SERVER_IDLE_TIMEOUT
+### server-idle-timeout
 
 | Arg                   | Env                  | Default |
 |-----------------------|----------------------|---------|
@@ -737,7 +738,7 @@ The expiration time of an ActivityPub actor IRI cache.
 
 The idle timeout for the HTTP server. For example, '30s' for a 30 second timeout.
 
-### WITNESS_POLICY_CACHE_EXPIRATION
+### witness-policy-cache-expiration
 
 | Arg                               | Env                              | Default |
 |-----------------------------------|----------------------------------|---------|

--- a/docs/source/orb/pubsub.md
+++ b/docs/source/orb/pubsub.md
@@ -35,14 +35,14 @@ the message to the original destination queue. If the message is rejected again,
 header value is set on the message, and the message is posted to a _wait_ queue. The expiration value is
 calculated by a backoff algorithm using the following parameters:
 
-- [Initial redelivery interval](parameters.html#mq-redelivery-initial-interval)
-- [Redelivery multiplier](parameters.html#mq-redelivery-multiplier)
-- [Maximum redelivery interval](parameters.html#mq-redelivery-max-interval)
+1) [mq-redelivery-initial-interval](parameters.html#mq-redelivery-initial-interval)
+2) [mq-redelivery-multiplier](parameters.html#mq-redelivery-multiplier)
+3) [mq-redelivery-max-interval](parameters.html#mq-redelivery-max-interval)
 
 The backoff algorithm increases the expiration with each redelivery attempt. For example, if the initial interval
 is set to 2s and the multiplier is set to 1.5 then the expiration is set 3s. The next time a redelivery of the
 message occurs, the expiration will be set to 4.5s. Expiration time is limited by parameter
-[Maximum redelivery interval](parameters.html#mq-redelivery-max-interval).
+[mq-redelivery-max-interval](parameters.html#mq-redelivery-max-interval).
 
 The _wait_ queue has no subscribers, so the message sits there until it expires. The _redelivery_ queue is also
 configured as the _dead-letter-queue_ for the _wait_ queue, so when the message expires it is automatically sent
@@ -64,18 +64,18 @@ The Publisher publishes messages over an AMQP channel to an AMQP server. There m
 over a single connection and (for performance reasons) it is advisable to use multiple channels to publish
 messages concurrently. Also, channels should be reused and not recreated each time (since there is also a performance
 penalty for creating and closing channels). A publisher channel pool is created when the startup
-parameter [mq-publisher-channel-pool-size](parameters.html#mq-publisher-pool) is greater than zero.
+parameter [mq-publisher-channel-pool-size](parameters.html#mq-publisher-channel-pool-size) is greater than zero.
 
 ## Subscriber Pool
 
 Each AMQP subscription is handled synchronously. If the handler takes a long time then subsequent messages in the queue
 need to wait until the previous message is processed. A subscriber pool may be configured for a given queue such that
 multiple subscribers concurrently process messages from the same queue. This setting is available for the following queues:
-- [op-queue-pool](parameters.html#op-queue-pool)
-- [mq-observer-pool](parameters.html#mq-observer-pool)
+1) [op-queue-pool](parameters.html#op-queue-pool)
+2) [mq-observer-pool](parameters.html#mq-observer-pool)
 
 Typically, all subscriber channels are created on the same AMQP connection, although an AMQP server may
 have a limit to the number of channels that can be opened for a single connection. Therefore, the limit for the number
 of subscriber channels for a single connection is specified by parameter
-[mq-max-connection-subscription](parameters.html#mq-max-connection-subscriptions). If the size of the subscriber pool
+[mq-max-connection-subscriptions](parameters.html#mq-max-connection-subscriptions). If the size of the subscriber pool
 reaches this limit then a new connection is automatically opened for any new subscriber channel.

--- a/docs/source/orb/taskmanager.md
+++ b/docs/source/orb/taskmanager.md
@@ -4,10 +4,10 @@ The Task Manager is an Orb service that periodically runs tasks on one Orb insta
 in the domain. A task is registered on startup with a unique ID, a run interval,
 and a function to invoke at the registered interval. The Task Manager stores a _permit_ for
 each task in the _orb-config_ database. The permit contains:
-- **Task ID**: The unique ID of the task
-- **Permit Holder**: The unique ID of the Orb instance that is currently responsible for running the task (a GUID that's generated on startup)
-- **Status**: Either _idle_ or _running_
-- **Update Time**: The last time the permit was updated (used to check the last time the task was run and the _aliveness_ of the permit holder)
+1) **Task ID**: The unique ID of the task
+2) **Permit Holder**: The unique ID of the Orb instance that is currently responsible for running the task (a GUID that's generated on startup)
+3) **Status**: Either _idle_ or _running_
+4) **Update Time**: The last time the permit was updated (used to check the last time the task was run and the _aliveness_ of the permit holder)
 
 The Task Manager on each Orb instance [periodically](parameters.html#task-manager-check-interval)
 checks the permit for each task. Different actions are taken depending on whether the Orb instance
@@ -69,7 +69,7 @@ parameter [data-expiry-check-interval](parameters.html#data-expiry-check-interva
 
 The [Activity Sync](onboardrecover.html#activity-sync-task) task periodically synchronizes anchor activities from the
 inboxes and outboxes of its followers and the domains that it's following. The scheduled period is set
-with the startup parameter [sync-interval](parameters.html#anchor-event-sync-interval).
+with the startup parameter [sync-interval](parameters.html#sync-interval).
 
 ### Anchor Status Monitor
 


### PR DESCRIPTION
Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>