### PR TITLE
docs: Docs for REST endpoints: cas, .well-known, nodeinfo, metrics

### DIFF
--- a/docs/source/orb/restendpoints/activitypub.md
+++ b/docs/source/orb/restendpoints/activitypub.md
@@ -7,10 +7,14 @@ The [ActivityAnchors](https://trustbloc.github.io/activityanchors/#actor-discove
 
 **Endpoint:** /services/orb
 
+### GET
+
 The Orb service is retrieved using the */services/orb* endpoint. The returned data is a JSON document
 that contains REST endpoints that may be queried to return additional information.
 
 **Example**
+
+Request:
 
 ```
 GET /services/orb HTTP/1.1
@@ -18,6 +22,8 @@ Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains the [service](https://trustbloc.github.io/activityanchors/#actor-discovery):
 
 ```json
 {
@@ -49,9 +55,13 @@ Accept-Encoding: gzip, deflate
 
 **Endpoint:** /services/orb/keys/[id]
 
+### GET
+
 The public key of an Orb service is retrieved using this endpoint.
 
 **Example**
+
+Request:
 
 ```
 GET /services/orb/keys/main-key HTTP/1.1
@@ -59,6 +69,8 @@ Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains the public key of the service:
 
 ```json
 {
@@ -72,6 +84,8 @@ Accept-Encoding: gzip, deflate
 
 **Endpoint:** /services/orb/followers
 
+### GET
+
 The followers of this Orb service are returned via this endpoint. If no paging parameters are specified in the
 URL then the response contains information about the collection, i.e. the links to the first and last page, as
 well as the total number of items in the collection. A subsequent request may be made using parameters
@@ -79,12 +93,16 @@ that include a specified page number in order to retrieve the actual items.
 
 **Example**
 
+Request page information:
+
 ```
 GET /services/orb/followers HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains page information:
 
 ```json
 {
@@ -97,12 +115,16 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+Request first page:
+
 ```
 GET /services/orb/followers?page=true&page-num=0 HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains items in the first page:
 
 ```json
 {
@@ -123,6 +145,8 @@ Accept-Encoding: gzip, deflate
 
 **Endpoint:** /services/orb/following
 
+### GET
+
 The services following this Orb service are returned via this endpoint. If no paging parameters are specified
 in the URL then the response contains information about the collection, i.e. the links to the first and last page, as
 well as the total number of items in the collection. A subsequent request may be made using parameters
@@ -130,12 +154,16 @@ that include a specified page number in order to retrieve the actual items.
 
 **Example**
 
+Request:
+
 ```
 GET /services/orb/following HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains page information:
 
 ```json
 {
@@ -148,12 +176,16 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+Request first page:
+
 ```
 GET /services/orb/following?page=true&page-num=0 HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains items from the first page:
 
 ```json
 {
@@ -188,12 +220,16 @@ using parameters that include a specified page number in order to retrieve the a
 
 **Example**
 
+Request page information:
+
 ```
 GET /services/orb/outbox HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains page information:
 
 ```json
 {
@@ -206,12 +242,16 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+Request page 41:
+
 ```
 GET /services/orb/outbox?page=true&page-num=41 HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains items from page 41:
 
 ```json
 {
@@ -373,9 +413,11 @@ which is usually an administrator token.
 
 **Example**
 
+Post a _Follow_ activity:
+
 ```
 POST /services/orb/outbox HTTP/1.1
-Host: orb.domain1.com
+Host: orb.domain2.com
 Content-Type: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 
@@ -393,6 +435,8 @@ Accept-Encoding: gzip, deflate
 
 **Endpoint:** /services/orb/inbox
 
+### GET
+
 The activities posted to the inbox of this service are returned via this endpoint. If no paging parameters are specified
 in the URL then the response contains information about the inbox collection, i.e. the links to the first and last page, as
 well as the total number of items in the inbox. A subsequent request may be made using parameters
@@ -400,12 +444,16 @@ that include a specified page number in order to retrieve the actual items.
 
 **Example**
 
+Request page information:
+
 ```
 GET /services/orb/inbox HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains page information:
 
 ```json
 {
@@ -418,12 +466,16 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+Request first page:
+
 ```
 GET /services/orb/inbox?page=true HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains items from the first page:
 
 ```json
 {
@@ -508,9 +560,43 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+### POST
+
+A POST request to the inbox endpoint adds the activity contained in the request to the service's Inbox,
+which will be processed by the ActivityPub [Inbox](../activitypub.html#outbox-inbox). This endpoint is restricted by
+authorization rules, i.e. the requester must sign the HTTP request. Some activities also have authorization rules
+such that the actor must be in the destination server's [followers](#followers) and/or [witnessing](#witnessing)
+collection.
+
+**Example**
+
+Post an _Invite_ activity:
+
+```
+POST /services/orb/inbox HTTP/1.1
+Host: orb.domain2.com
+Content-Type: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
+Accept-Encoding: gzip, deflate
+
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "actor": "https://orb.domain1.com/services/orb",
+  "id": "https://orb.domain1.com/services/orb/activities/34e67f25-4832-4c62-a199-5614ec3e5582",
+  "object": "https://w3id.org/activityanchors#AnchorWitness",
+  "target": "https://orb.domain2.com/services/orb",
+  "to": "https://orb.domain2.com/services/orb",
+  "type": "Invite"
+}
+```
+
 ## Witnesses
 
 **Endpoint:** /services/orb/witnesses
+
+### GET
 
 The witnesses of this service are returned via this endpoint. If no paging parameters are specified
 in the URL then the response contains information about the _witnesses_ collection, i.e. the links to the first and last page, as
@@ -519,12 +605,16 @@ that include a specified page number in order to retrieve the actual items.
 
 **Example**
 
+Request page information:
+
 ```
 GET /services/orb/witnesses HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains page information:
 
 ```json
 {
@@ -537,12 +627,16 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+Request page 4:
+
 ```
 GET /services/orb/witnesses??page=true&page-num=4 HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains items from page 4:
 
 ```json
 {
@@ -562,6 +656,8 @@ Accept-Encoding: gzip, deflate
 
 **Endpoint:** /services/orb/witnessing
 
+### GET
+
 The services that are witnessing anchor events for this service are returned via this endpoint. If no paging parameters are specified
 in the URL then the response contains information about the collection, i.e. the links to the first and last page, as
 well as the total number of items in the collection. A subsequent request may be made using parameters
@@ -569,12 +665,16 @@ that include a specified page number in order to retrieve the actual items.
 
 **Example**
 
+Request page information:
+
 ```
 GET /services/orb/witnessing HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains page information:
 
 ```json
 {
@@ -587,12 +687,16 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+Request first page:
+
 ```
 GET /services/orb/witnessing?page=true HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains items from the first page:
 
 ```json
 {
@@ -613,6 +717,8 @@ Accept-Encoding: gzip, deflate
 
 **Endpoint:** /services/orb/liked
 
+### GET
+
 The anchor events that are _liked_ are returned via this endpoint. (Liked means that the
 anchors in the response were all added to the ledger.) If no paging parameters are specified in the URL then the response
 contains information about the collection, i.e. the links to the first and last page, as well as the total number of
@@ -621,12 +727,16 @@ to retrieve the actual items.
 
 **Example**
 
+Request page information:
+
 ```
 GET /services/orb/liked HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains page information:
 
 ```json
 {
@@ -639,12 +749,16 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+Request first page:
+
 ```
 GET /services/orb/liked?page=true HTTP/1.1
 Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains items from the first page:
 
 ```json
 {
@@ -667,6 +781,8 @@ Accept-Encoding: gzip, deflate
 
 **Endpoint:** /services/orb/likes/[id]
 
+### GET
+
 This endpoint returns a collection of _Like_ activities for a given anchor. If no paging parameters are specified
 in the URL then the response contains information about the collection, i.e. the links to the first and last page, as
 well as the total number of items in the collection. A subsequent request may be made using parameters
@@ -674,12 +790,16 @@ that include a specified page number in order to retrieve the actual items.
 
 **Example**
 
+Request page information:
+
 ```
 GET /services/orb/likes/hl%3AuEiAkSqfSi_HWPU4boZeeCPvpCnNU3VM2vSsbIcNfQWWRQg%3AuoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWtTcWZTaV9IV1BVNGJvWmVlQ1B2cENuTlUzVk0ydlNzYkljTmZRV1dSUWc HTTP/1.1
 Host: orb.domain2.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains page information:
 
 ```json
 {
@@ -692,12 +812,16 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+Request first page:
+
 ```
 GET /services/orb/likes/hl%3AuEiAkSqfSi_HWPU4boZeeCPvpCnNU3VM2vSsbIcNfQWWRQg%3AuoQ-BeEtodHRwczovL29yYi5kb21haW4yLmNvbS9jYXMvdUVpQWtTcWZTaV9IV1BVNGJvWmVlQ1B2cENuTlUzVk0ydlNzYkljTmZRV1dSUWc?page=true&page-num=0 HTTP/1.1
 Host: orb.domain2.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains items from the first page:
 
 ```json
 {
@@ -736,6 +860,8 @@ Accept-Encoding: gzip, deflate
 
 **Endpoint:** /services/orb/shares/[id]
 
+### GET
+
 The _Create_ activities that were _Announced_ are returned via this endpoint. If no paging parameters are specified in the URL
 then the response contains information about the collection, i.e. the links to the first and last page, as well as the total number of
 items in the collection. A subsequent request may be made using parameters that include a specified page number in order
@@ -743,12 +869,16 @@ to retrieve the actual items.
 
 **Example**
 
+Request page information:
+
 ```
 GET /services/orb/shares/hl%3AuEiA-wMFlsv-OGRDiSgxqc_TmJzuRpTRcm7s2FOXkH-oJRg%3AuoQ-BeEJpcGZzOi8vYmFma3JlaWI2eWRhd2xteDdyeW1yYnlza2JydmhoNWhnZTQ1emRqanVsc24zd25xdTR4c2I3MnFqaXk HTTP/1.1
 Host: orb.domain3.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains page information:
 
 ```json
 {
@@ -761,12 +891,16 @@ Accept-Encoding: gzip, deflate
 }
 ```
 
+Request first page:
+
 ```
 GET /services/orb/shares/hl%3AuEiA-wMFlsv-OGRDiSgxqc_TmJzuRpTRcm7s2FOXkH-oJRg%3AuoQ-BeEJpcGZzOi8vYmFma3JlaWI2eWRhd2xteDdyeW1yYnlza2JydmhoNWhnZTQ1emRqanVsc24zd25xdTR4c2I3MnFqaXk?page=true HTTP/1.1
 Host: orb.domain3.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains items from the first page:
 
 ```json
 {
@@ -869,9 +1003,13 @@ Accept-Encoding: gzip, deflate
 
 **Endpoint:** /services/orb/activities/[id]
 
+### GET
+
 This endpoint returns an activity for the specified ID.
 
 **Example**
+
+Request:
 
 ```
 GET /services/orb/activities/91dbb2e2-1040-4fd5-bd2e-1bcd67bdda8a HTTP/1.1
@@ -879,6 +1017,8 @@ Host: orb.domain1.com
 Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 Accept-Encoding: gzip, deflate
 ```
+
+Response contains the activity:
 
 ````json
 {
@@ -904,12 +1044,51 @@ Accept-Encoding: gzip, deflate
 
 An [accept list](../activitypub.html#accept-list) is a database of server URLs that are authorized for a particular type of operation.
 
+### GET
+
+The accept-list is retrieved using a GET request to this endpoint.
+
+**Example**
+
+Request:
+
+```
+GET /services/orb/acceptlist HTTP/1.1
+Host: orb.domain1.com
+Accept: application/ld+json
+Accept-Encoding: gzip, deflate
+```
+
+Response contains the accept-list for both _follow_ and _invite-witness_:
+
+```json
+[
+  {
+    "type": "follow",
+    "url": [
+      "https://orb.domain2.com/services/orb",
+      "https://orb.domain3.com/services/orb"
+    ]
+  },
+  {
+    "type": "invite-witness",
+    "url": [
+      "https://orb.domain2.com/services/orb",
+      "https://orb.domain3.com/services/orb"
+    ]
+  }
+]
+```
+
 ### POST
 
 The accept-list is updated using a POST request to this endpoint. Services may
 be added and removed from the accept-list for _Follow_ and _Invite_ witness activities.
 
 **Example**
+
+Request to add domain2 and domain3 to the _follow_ and _invite-witness_ accept-list as well as remove domain4
+from the _follow_ accept-list:
 
 ```
 POST /services/orb/acceptlist HTTP/1.1
@@ -934,38 +1113,6 @@ Accept-Encoding: gzip, deflate
       "https://orb.domain3.com/services/orb"
     ],
     "type": "invite-witness"
-  }
-]
-```
-
-### GET
-
-The accept-list is retrieved using a GET request to this endpoint.
-
-**Example**
-
-```
-GET /services/orb/acceptlist HTTP/1.1
-Host: orb.domain1.com
-Accept: application/ld+json
-Accept-Encoding: gzip, deflate
-```
-
-```json
-[
-  {
-    "type": "follow",
-    "url": [
-      "https://orb.domain2.com/services/orb",
-      "https://orb.domain3.com/services/orb"
-    ]
-  },
-  {
-    "type": "invite-witness",
-    "url": [
-      "https://orb.domain2.com/services/orb",
-      "https://orb.domain3.com/services/orb"
-    ]
   }
 ]
 ```

--- a/docs/source/orb/restendpoints/cas.md
+++ b/docs/source/orb/restendpoints/cas.md
@@ -1,3 +1,59 @@
-# CAS Endpoints
+# CAS Endpoint
 
-/cas/[cid]
+**Endpoint:** /cas/[id]
+
+### GET
+
+Returns content stored in the Content Addressable Storage (CAS). The ID is either an IPFS
+[CID](https://docs.ipfs.io/concepts/content-addressing/) or the hash of the content.
+
+**Example**
+
+Request an [AnchorEvent](https://trustbloc.github.io/activityanchors/#anchorevent) using its hash as the ID:
+
+```
+GET /cas/uEiD6mDyC3YodyjfNfmIE3jYzGSDalDqj8Syj-wY4IAC8yA HTTP/1.1
+Host: orb.domain1.com
+Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
+Accept-Encoding: gzip, deflate
+```
+
+Response contains the [AnchorEvent](https://trustbloc.github.io/activityanchors/#anchorevent):
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/activityanchors/v1"
+  ],
+  "attachment": [
+    {
+      "content": "{\"properties\":{\"https://w3id.org/activityanchors#generator\":\"https://w3id.org/orb#v0\",\"https://w3id.org/activityanchors#resources\":[{\"id\":\"did:orb:uAAA:EiBfWqeAJfENeHLABsYIYmsIqtk-bsmvJmoR6IgISd6ZcA\"},{\"id\":\"did:orb:uAAA:EiAdTRM3nwkp6lsn2n17_T-t7j4xT4IJxSXgfBCB3exZ2g\"},{\"id\":\"did:orb:uAAA:EiDllWjlTcoNyL5roXFRzdnWvygPT5FHbISVjwDNAD98tA\"},{\"id\":\"did:orb:uAAA:EiC6Sjz56-iawx_CUl3xoIykVG1iKtvh78zRl93WHFkQdA\"},{\"id\":\"did:orb:uAAA:EiADvRR2cTIv8si57Tl2puoqpIWK41L9rb9aVF2gdrKhyg\"}]},\"subject\":\"hl:uEiCVVS-n0wx0OfeEXBM9jcGNOcMEArYYWPIxk5D_l96ySg:uoQ-BeEJpcGZzOi8vYmFma3JlaWV2a3V4MnB1eW1vcTQ3cGJjNGNtNnkzcW1uaGhicWlhdndkYm1wZW1tdHNkN3pweHZzamk\"}",
+      "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
+      "tag": [
+        {
+          "href": "hl:uEiDSkSE5Oxl6Z6Tr6wGMW1dnlC6HaZrcGURNo6dSeQ2jzA",
+          "rel": [
+            "witness"
+          ],
+          "type": "Link"
+        }
+      ],
+      "type": "AnchorObject",
+      "url": "hl:uEiD96Zjp10atu2DPV1VbSxZmMvk5r5iAvSlnXXAfpkpY9g"
+    },
+    {
+      "content": "{\"@context\":[\"https://www.w3.org/2018/credentials/v1\"],\"credentialSubject\":\"hl:uEiD96Zjp10atu2DPV1VbSxZmMvk5r5iAvSlnXXAfpkpY9g\",\"id\":\"https://orb.domain2.com/vc/afeead95-8507-460b-a73c-cf9b4853b4a9\",\"issuanceDate\":\"2022-02-22T15:45:41.6601759Z\",\"issuer\":\"https://orb.domain2.com\",\"proof\":[{\"created\":\"2022-02-22T15:45:41.6613096Z\",\"domain\":\"https://orb.domain2.com\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2Sp1wXzI69pontDt-x26KwEBFhEzif33io9lIEHEEBRHgiLAFr4D6XDDVyjMmSCXWWuYBMZUFWwwHJkpPi08Dg\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain2.com#orb2key\"},{\"created\":\"2022-02-22T15:45:42.664Z\",\"domain\":\"http://orb.vct:8077/maple2020\",\"jws\":\"eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.._vShdZ5z_YKjWfKPt5zgTJpUoYx1pMfjETiFVHHVsZrUlAM9CXLSjrRAzGicT4uqTVFqurrpsQstPAABpm_DDQ\",\"proofPurpose\":\"assertionMethod\",\"type\":\"Ed25519Signature2018\",\"verificationMethod\":\"did:web:orb.domain1.com#orb1key2\"}],\"type\":\"VerifiableCredential\"}",
+      "generator": "https://w3id.org/orb#v0",
+      "mediaType": "application/json",
+      "type": "AnchorObject",
+      "url": "hl:uEiDSkSE5Oxl6Z6Tr6wGMW1dnlC6HaZrcGURNo6dSeQ2jzA"
+    }
+  ],
+  "attributedTo": "https://orb.domain2.com/services/orb",
+  "index": "hl:uEiD96Zjp10atu2DPV1VbSxZmMvk5r5iAvSlnXXAfpkpY9g",
+  "published": "2022-02-22T15:45:41.6437395Z",
+  "type": "AnchorEvent"
+}
+```

--- a/docs/source/orb/restendpoints/index.rst
+++ b/docs/source/orb/restendpoints/index.rst
@@ -11,5 +11,4 @@ REST Endpoints
    witness-policy.md
    ld-context.md
    vc.md
-   nodeinfo.md
-   metrics.md
+   system.md

--- a/docs/source/orb/restendpoints/metrics.md
+++ b/docs/source/orb/restendpoints/metrics.md
@@ -1,3 +1,0 @@
-# Metrics Endpoint
-
-## /metrics

--- a/docs/source/orb/restendpoints/nodeinfo.md
+++ b/docs/source/orb/restendpoints/nodeinfo.md
@@ -1,9 +1,0 @@
-# Node Info Endpoints
-
-## Node Info version 2.0
-
-/nodeinfo/2.0
-
-## Node Info version 2.1
-
-/nodeinfo/2.1

--- a/docs/source/orb/restendpoints/system.md
+++ b/docs/source/orb/restendpoints/system.md
@@ -1,0 +1,196 @@
+# System Endpoints
+
+Various endpoints are defined to retrieve system information, such as Orb version and metrics.
+
+## Node Info Endpoints
+
+The NodeInfo endpoints provide general information about an Orb server, including the version, the number
+of posts ([Create](https://trustbloc.github.io/activityanchors/#create-activity) activities) and the number of
+comments ([Like](https://trustbloc.github.io/activityanchors/#like-activity) activities). Two versions of NodeInfo
+are supported:
+[v2.0](https://nodeinfo.diaspora.software/docson/index.html#/ns/schema/2.0#$$expand) and
+[v2.1](https://nodeinfo.diaspora.software/docson/index.html#/ns/schema/2.1#$$expand).
+
+### Node Info version 2.0
+
+**Endpoint:** /nodeinfo/2.0
+
+### GET
+
+**Example**
+
+Request:
+
+```
+GET /nodeinfo/2.0 HTTP/1.1
+Host: orb.domain1.com
+Accept: application/json
+Accept-Encoding: gzip, deflate
+```
+
+Response:
+
+```json
+{
+  "version": "2.0",
+  "software": {
+    "name": "Orb",
+    "version": "0.1.2"
+  },
+  "protocols": [
+    "activitypub"
+  ],
+  "services": {
+    "inbound": [],
+    "outbound": []
+  },
+  "openRegistrations": false,
+  "usage": {
+    "users": {
+      "total": 1
+    },
+    "localPosts": 4,
+    "localComments": 6
+  }
+}
+```
+
+### Node Info version 2.1
+
+**Endpoint:** /nodeinfo/2.1
+
+### GET
+
+**Example**
+
+Request:
+
+```
+GET /nodeinfo/2.1 HTTP/1.1
+Host: orb.domain1.com
+Accept: application/json
+Accept-Encoding: gzip, deflate
+```
+
+Response:
+
+```json
+{
+  "version": "2.1",
+  "software": {
+    "name": "Orb",
+    "version": "0.1.2",
+    "repository": "https://github.com/trustbloc/orb"
+  },
+  "protocols": [
+    "activitypub"
+  ],
+  "services": {
+    "inbound": [],
+    "outbound": []
+  },
+  "openRegistrations": false,
+  "usage": {
+    "users": {
+      "total": 1
+    },
+    "localPosts": 4,
+    "localComments": 6
+  }
+}
+```
+
+## Metrics Endpoint
+
+**Endpoint:** /metrics
+
+### GET
+
+This endpoint retrieves metrics data that may be consumed by a [prometheus](https://prometheus.io/) server.
+
+Request:
+
+```
+GET /metrics HTTP/1.1
+Host: orb.domain1.com
+Accept: text/plain
+Accept-Encoding: gzip, deflate
+```
+
+Response:
+
+```
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 6.49e-05
+go_gc_duration_seconds{quantile="0.25"} 0.0001778
+go_gc_duration_seconds{quantile="0.5"} 0.0002633
+go_gc_duration_seconds{quantile="0.75"} 0.0004953
+go_gc_duration_seconds{quantile="1"} 0.0111963
+go_gc_duration_seconds_sum 0.1513972
+go_gc_duration_seconds_count 248
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 104
+# HELP orb_activitypub_inbox_handler_seconds The time (in seconds) that it takes to handle an activity posted to the inbox.
+# TYPE orb_activitypub_inbox_handler_seconds histogram
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="0.005"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="0.01"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="0.025"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="0.05"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="0.1"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="0.25"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="0.5"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="1"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="2.5"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="5"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="10"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Accept",le="+Inf"} 1
+orb_activitypub_inbox_handler_seconds_sum{type="Accept"} 0.1140751
+orb_activitypub_inbox_handler_seconds_count{type="Accept"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="0.005"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="0.01"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="0.025"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="0.05"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="0.1"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="0.25"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="0.5"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="1"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="2.5"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="5"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="10"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Announce",le="+Inf"} 0
+orb_activitypub_inbox_handler_seconds_sum{type="Announce"} 0
+orb_activitypub_inbox_handler_seconds_count{type="Announce"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="0.005"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="0.01"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="0.025"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="0.05"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="0.1"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="0.25"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="0.5"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="1"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="2.5"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="5"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="10"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Create",le="+Inf"} 1
+orb_activitypub_inbox_handler_seconds_sum{type="Create"} 0.2653678
+orb_activitypub_inbox_handler_seconds_count{type="Create"} 1
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="0.005"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="0.01"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="0.025"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="0.05"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="0.1"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="0.25"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="0.5"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="1"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="2.5"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="5"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="10"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="Follow",le="+Inf"} 0
+orb_activitypub_inbox_handler_seconds_sum{type="Follow"} 0
+orb_activitypub_inbox_handler_seconds_count{type="Follow"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="InviteWitness",le="0.005"} 0
+orb_activitypub_inbox_handler_seconds_bucket{type="InviteWitness",le="0.01"} 0
+. . .
+```

--- a/docs/source/orb/restendpoints/vc.md
+++ b/docs/source/orb/restendpoints/vc.md
@@ -1,3 +1,3 @@
 # VC Endpoints
 
-/vc/[id]
+**Endpoint:** /vc/[id]

--- a/docs/source/orb/restendpoints/wellknown.md
+++ b/docs/source/orb/restendpoints/wellknown.md
@@ -1,25 +1,229 @@
 # .well-known Endpoints
 
+The [.well-known](https://datatracker.ietf.org/doc/html/rfc5785) endpoints are used for discovery of services within an Orb domain.
+
 ## did-orb
 
-/.well-known/did-orb
+**Endpoint:** /.well-known/did-orb
 
-## webfinger
+### GET
 
-/.well-known/webfinger
+***Example***
+
+Request:
+
+```
+GET /.well-known/did-orb HTTP/1.1
+Host: orb.domain1.com
+Accept: application/json
+```
+
+Response:
+
+```json
+{
+  "resolutionEndpoint": "https://orb.domain1.com/sidetree/v1/identifiers",
+  "operationEndpoint": "https://orb.domain1.com/sidetree/v1/operations"
+}
+```
 
 ## host-meta
 
-/.well-known/host-meta
+**Endpoint:** /.well-known/host-meta
+
+### GET
+
+***Example***
+
+Request:
+
+```
+GET /.well-known/host-meta HTTP/1.1
+Host: orb.domain1.com
+Accept: application/json
+```
+
+Response:
+
+```json
+{
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/jrd+json",
+      "template": "https://orb.domain1.com/.well-known/webfinger?resource={uri}"
+    },
+    {
+      "rel": "self",
+      "type": "application/activity+json",
+      "href": "https://orb.domain1.com/services/orb"
+    }
+  ]
+}
+```
 
 ## host-meta.json
 
-/.well-known/host-meta.json
+**Endpoint:** /.well-known/host-meta.json
 
+### GET
+
+***Example***
+
+Request:
+
+```
+GET /.well-known/host-meta.json HTTP/1.1
+Host: orb.domain1.com
+```
+
+Response:
+
+```json
+{
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/jrd+json",
+      "template": "https://orb.domain1.com/.well-known/webfinger?resource={uri}"
+    },
+    {
+      "rel": "self",
+      "type": "application/activity+json",
+      "href": "https://orb.domain1.com/services/orb"
+    }
+  ]
+}
+```
 ## did.json
 
-/.well-known/did.json
+**Endpoint:** /.well-known/did.json
+
+### GET
+
+***Example***
+
+Request:
+
+```
+GET /.well-known/did.json HTTP/1.1
+Host: orb.domain1.com
+```
+
+Response:
+
+```json
+{
+  "@context": "https://w3id.org/did/v1",
+  "id": "did:web:orb.domain1.com",
+  "verificationMethod": [
+    {
+      "id": "did:web:orb.domain1.com#orb1key2",
+      "controller": "did:web:orb.domain1.com",
+      "type": "Ed25519VerificationKey2018",
+      "publicKeyBase58": "Cd5DEcovdeweWWkMzXL5XmvtL5ov1jgcf7i6itnbVz8m"
+    },
+    {
+      "id": "did:web:orb.domain1.com#orb1key",
+      "controller": "did:web:orb.domain1.com",
+      "type": "Ed25519VerificationKey2018",
+      "publicKeyBase58": "245RycEHD7YAaaELTdUBLGF66iehCzpT3qy1jHLZoTMX"
+    }
+  ],
+  "authentication": [
+    "did:web:orb.domain1.com#orb1key2",
+    "did:web:orb.domain1.com#orb1key"
+  ],
+  "assertionMethod": [
+    "did:web:orb.domain1.com#orb1key2",
+    "did:web:orb.domain1.com#orb1key"
+  ],
+  "capabilityDelegation": [
+    "did:web:orb.domain1.com#orb1key2",
+    "did:web:orb.domain1.com#orb1key"
+  ],
+  "capabilityInvocation": [
+    "did:web:orb.domain1.com#orb1key2",
+    "did:web:orb.domain1.com#orb1key"
+  ]
+}
+```
+
+## webfinger
+
+**Endpoint:** /.well-known/webfinger?resource={uri}
+
+### GET
+
+***Example***
+
+Request information about a specific DID:
+
+```
+GET /.well-known/webfinger?resource=did:orb:uEiDYK49ULtocB0ecZB5kzdo1oCAbJEJmAr65xpoWDq3Y1w:EiAWa2VAwDV3iC7q2nWygTy4b5AuwfTnf1g_ZYPZJFnJRA
+Host: orb.domain1.com
+Accept: application/json
+```
+
+Response:
+
+```json
+{
+  "properties": {
+    "https://trustbloc.dev/ns/anchor-origin": "https://orb.domain1.com",
+    "https://trustbloc.dev/ns/min-resolvers": 1
+  },
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/did+ld+json",
+      "href": "https://orb.domain1.com/sidetree/v1/identifiers/did:orb:uEiB9vhEm-4i8Vn1NSLcjYH50IsLCuGYDsKHpCEn6T0VHMg:EiAWa2VAwDV3iC7q2nWygTy4b5AuwfTnf1g_ZYPZJFnJRA"
+    },
+    {
+      "rel": "via",
+      "type": "application/ld+json",
+      "href": "hl:uEiB9vhEm-4i8Vn1NSLcjYH50IsLCuGYDsKHpCEn6T0VHMg:uoQ-BeEJpcGZzOi8vYmFma3JlaWQ1eHlpc242NGl4cmxoMnRraXc0cndhN3R1ZWxibWZvZGdhb3lrZDJpaWpoNWU2cmtoZ2k"
+    },
+    {
+      "rel": "service",
+      "type": "application/activity+json",
+      "href": "https://orb.domain1.com/services/orb"
+    }
+  ]
+}
+```
 
 ## nodeinfo
 
-/.well-known/nodeinfo
+**Endpoint:** /.well-known/nodeinfo
+
+### GET
+
+Returns the [NodeInfo](system.html#node-info-endpoints) endpoints that may be queried to provide general information about an Orb server.
+
+***Example***
+
+Request:
+
+```
+GET /.well-known/nodeinfo HTTP/1.1
+Host: orb.domain1.com
+Accept: application/json
+```
+
+Response:
+
+```
+{
+  "links": [
+    {
+      "rel": "http://nodeinfo.diaspora.software/ns/schema/2.0",
+      "href": "https://orb.domain1.com/nodeinfo/2.0"
+    },
+    {
+      "rel": "http://nodeinfo.diaspora.software/ns/schema/2.1",
+      "href": "https://orb.domain1.com/nodeinfo/2.1"
+    }
+  ]
+}
+```

--- a/docs/source/orb/restendpoints/witness-policy.md
+++ b/docs/source/orb/restendpoints/witness-policy.md
@@ -1,5 +1,19 @@
 # Witness Policy Endpoints
 
-/policy
+**Endpoint:** /policy
 
-Configure witness policy as per [Witness Policy](witnesspolicy.html#witness-policy)
+### POST
+
+Configures the witness policy as per [Witness Policy](../witnesspolicy.html#witness-policy)
+
+**Example**
+
+Request:
+
+```
+POST /policy HTTP/1.1
+Host: orb.domain1.com
+Content-Type: text/plain
+
+MinPercent(100,batch) AND MinPercent(50,system)
+```


### PR DESCRIPTION
Also fixed docs for ActivityPub endpoints.

closes trustbloc/orb#1052
closes trustbloc/orb#1050
closes trustbloc/orb#1047

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>