### PR TITLE
docs: Removed operation queue retry parameters

### DIFF
--- a/readthedocs/source/orb/parameters.md
+++ b/readthedocs/source/orb/parameters.md
@@ -422,31 +422,6 @@ to the queue, so that they will be processed by another Orb instance.
 
 The maximum number of times an operation may be reposted to the queue after having failed.
 
-### op-queue-repost-initial-delay
-
-| Arg                             | Env                           | Default |
-|---------------------------------|-------------------------------|---------|
-| --op-queue-repost-initial-delay | OP_QUEUE_REPOST_INITIAL_DELAY | 5s      |
-
-The delay for the initial retry attempt after having failed to process the operation in the queue.
-
-### op-queue-repost-max-delay
-
-| Arg                         | Env                       | Default |
-|-----------------------------|---------------------------|---------|
-| --op-queue-repost-max-delay | OP_QUEUE_REPOST_MAX_DELAY | 1m      |
-
-The maximum delay of a retry attempt after having failed to process the operation in the queue.
-
-### op-queue-repost-multiplier
-
-| Arg                          | Env                        | Default |
-|------------------------------|----------------------------|---------|
-| --op-queue-repost-multiplier | OP_QUEUE_REPOST_MULTIPLIER | 1.5     |
-
-The multiplier for a retry attempt after having failed to process the operation in the queue. For example, if set
-to 1.5 and the previous retry delay was 2s then the next retry delay is set to 3s.
-
 ### cid-version
 
 | Arg           | Env          | Default |

--- a/readthedocs/source/orb/system/batchwriter.md
+++ b/readthedocs/source/orb/system/batchwriter.md
@@ -75,9 +75,9 @@ operations then the _Nack_ function is called. The _Nack_ function reposts the o
 so they may be retried (potentially by another server instance) and the operations are deleted from the database.
 Each operation message is reposted with a delay to give the server a chance to recover from whatever caused
 processing to fail in the first place. The delay is calculated according to the number of failed retries along with parameters,
-[op-queue-repost-initial-delay](../parameters.html#op-queue-repost-initial-delay),
-[op-queue-repost-max-delay](../parameters.html#op-queue-repost-max-delay),
-and [op-queue-repost-multiplier](../parameters.html#op-queue-repost-multiplier). The _retries_
+[mq-redelivery-initial-interval](../parameters.html#mq-redelivery-initial-interval),
+[mq-redelivery-max-interval](../parameters.html#mq-redelivery-max-interval),
+and [mq-redelivery-multiplier](../parameters.html#mq-redelivery-multiplier). The _retries_
 header value is also set on the message. The value is first incremented before it is reposted. Once the maximum number of
 retries for an operation has been reached, the operation is discarded.
 


### PR DESCRIPTION
The operation queue retry parameters were removed and replaced with the existing, MQ retry parameters.

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>