### PR TITLE
chore: Remove additional also known as from example

### DIFF
--- a/readthedocs/source/orb/restendpoints/did-web.md
+++ b/readthedocs/source/orb/restendpoints/did-web.md
@@ -26,7 +26,6 @@ Response:
     "https://w3id.org/security/suites/ed25519-2018/v1"
   ],
   "alsoKnownAs": [
-    "https://myblog.example/",
     "did:orb:uEiDDV4Yn9wx0c5dlrYT90TsjB6fg2Gc6x91X1gG3O5oJIA:EiCNuOisUYmxNfT2HugwwMYQAyzLr9FxI7tbT3eb5r3mFQ",
     "did:orb:hl:uEiDDV4Yn9wx0c5dlrYT90TsjB6fg2Gc6x91X1gG3O5oJIA:uoQ-BeEtodHRwczovL29yYi5kb21haW4zLmNvbS9jYXMvdUVpRERWNFluOXd4MGM1ZGxyWVQ5MFRzakI2ZmcyR2M2eDkxWDFnRzNPNW9KSUE:EiCNuOisUYmxNfT2HugwwMYQAyzLr9FxI7tbT3eb5r3mFQ"
   ],

--- a/readthedocs/source/orb/restendpoints/sidetree.md
+++ b/readthedocs/source/orb/restendpoints/sidetree.md
@@ -713,7 +713,6 @@ Response:
       "https://w3id.org/security/suites/ed25519-2018/v1"
     ],
     "alsoKnownAs": [
-      "https://myblog.example/",
       "did:orb:uEiDDV4Yn9wx0c5dlrYT90TsjB6fg2Gc6x91X1gG3O5oJIA:EiCNuOisUYmxNfT2HugwwMYQAyzLr9FxI7tbT3eb5r3mFQ",
       "did:orb:hl:uEiDDV4Yn9wx0c5dlrYT90TsjB6fg2Gc6x91X1gG3O5oJIA:uoQ-BeEtodHRwczovL29yYi5kb21haW4zLmNvbS9jYXMvdUVpRERWNFluOXd4MGM1ZGxyWVQ5MFRzakI2ZmcyR2M2eDkxWDFnRzNPNW9KSUE:EiCNuOisUYmxNfT2HugwwMYQAyzLr9FxI7tbT3eb5r3mFQ"
     ],


### PR DESCRIPTION
Remove additional also known as from did:web examples e.g. https://myblog.example/

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>